### PR TITLE
also query features at point in OSM link

### DIFF
--- a/public/ge0.html
+++ b/public/ge0.html
@@ -148,7 +148,7 @@
       <a id="install" href="/get.html" target="_blank" class="linkcolour link">
         Install Organic Maps
       </a>
-      <a href="https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=${zoom}/${lat}/${lon}" target="_blank" class="linkcolour link">
+      <a href="https://www.osm.org/query?mlat=${lat}&mlon=${lon}&lat=${lat}&lon=${lon}#map=${zoom}/${lat}/${lon}" target="_blank" class="linkcolour link">
         See on OpenStreetMap
       </a>
       <div class="link">


### PR DESCRIPTION
Also query features around the marker when viewing on OSM, for easier selection.

Before/after:

https://github.com/organicmaps/url-processor/assets/26939824/5583c3a8-a241-4b0e-b63b-4e0701696764

It's slightly hacky because it needs both mlon/mlat and lon/lat. and the #map section (with another lon/lat) is required to specify the zoom. but it does work!
